### PR TITLE
Fixed an API misconnect ('release, not destroy')

### DIFF
--- a/src/core/Pool.js
+++ b/src/core/Pool.js
@@ -38,7 +38,7 @@
             return this._getList(obj.__puid).push(obj);
         },
 
-        destroy: function() {
+        release: function() {
             for (var id in this.list) {
                 this.list[id].length = 0;
                 delete this.list[id];


### PR DESCRIPTION
Simple issue, simple fix... Pool.destroy calls 'release' on its Pool object; 'destroy' was implemented on Pool, but not 'release'. 'Release' nomenclature sounds more appropriate (and I don't see any knock on issues), so I've changed the function name here.
