### PR TITLE
fix: correct negated expression for Object.defineProperty check (#101)

### DIFF
--- a/example/game/crafty/js/crafty.js
+++ b/example/game/crafty/js/crafty.js
@@ -4303,7 +4303,7 @@ Crafty.storage = (function () {
     * Is `Object.defineProperty` supported?
     */
     support.defineProperty = (function () {
-        if (!'defineProperty' in Object) return false;
+        if (!('defineProperty' in Object)) return false;
         try { Object.defineProperty({}, 'x', {}); }
         catch (e) { return false };
         return true;


### PR DESCRIPTION
This pull request fixes an issue with the incorrect negated expression used to check the existence of Object.defineProperty. The original condition did not properly evaluate the presence of defineProperty in the Object object.

Issue Addressed - [101](https://github.com/drawcall/Proton/issues/101).  by [@gorosgobe](https://github.com/gorosgobe)